### PR TITLE
Ssl cert pinning update fix

### DIFF
--- a/MDCNetworking.xcodeproj/project.pbxproj
+++ b/MDCNetworking.xcodeproj/project.pbxproj
@@ -17,7 +17,7 @@
 		6DA77EFC1E02FEA800D3E3B1 /* MDCNetworking.h in Headers */ = {isa = PBXBuildFile; fileRef = 6DA77EEE1E02FEA800D3E3B1 /* MDCNetworking.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		6DA77F061E02FEC200D3E3B1 /* ErrorHandling.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DA77F051E02FEC200D3E3B1 /* ErrorHandling.swift */; };
 		6DA77F081E0404B300D3E3B1 /* NetworkingErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DA77F071E0404B300D3E3B1 /* NetworkingErrorTests.swift */; };
-		6DA77F0A1E07E06E00D3E3B1 /* NetworkConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DA77F091E07E06E00D3E3B1 /* NetworkConfiguration.swift */; };
+		6DA77F0A1E07E06E00D3E3B1 /* Configuration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DA77F091E07E06E00D3E3B1 /* Configuration.swift */; };
 		6DA77F0C1E07F81E00D3E3B1 /* ConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DA77F0B1E07F81E00D3E3B1 /* ConfigurationTests.swift */; };
 		6DA77F0E1E08022F00D3E3B1 /* ClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DA77F0D1E08022F00D3E3B1 /* ClientTests.swift */; };
 		6DA77F101E0802B500D3E3B1 /* NetworkClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DA77F0F1E0802B500D3E3B1 /* NetworkClient.swift */; };
@@ -54,7 +54,7 @@
 		6DA77EFB1E02FEA800D3E3B1 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		6DA77F051E02FEC200D3E3B1 /* ErrorHandling.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ErrorHandling.swift; sourceTree = "<group>"; };
 		6DA77F071E0404B300D3E3B1 /* NetworkingErrorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NetworkingErrorTests.swift; sourceTree = "<group>"; };
-		6DA77F091E07E06E00D3E3B1 /* NetworkConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NetworkConfiguration.swift; sourceTree = "<group>"; };
+		6DA77F091E07E06E00D3E3B1 /* Configuration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Configuration.swift; sourceTree = "<group>"; };
 		6DA77F0B1E07F81E00D3E3B1 /* ConfigurationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ConfigurationTests.swift; sourceTree = "<group>"; };
 		6DA77F0D1E08022F00D3E3B1 /* ClientTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ClientTests.swift; sourceTree = "<group>"; };
 		6DA77F0F1E0802B500D3E3B1 /* NetworkClient.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NetworkClient.swift; sourceTree = "<group>"; };
@@ -121,7 +121,7 @@
 				6DA77EEE1E02FEA800D3E3B1 /* MDCNetworking.h */,
 				6DA77EEF1E02FEA800D3E3B1 /* Info.plist */,
 				6DA77F051E02FEC200D3E3B1 /* ErrorHandling.swift */,
-				6DA77F091E07E06E00D3E3B1 /* NetworkConfiguration.swift */,
+				6DA77F091E07E06E00D3E3B1 /* Configuration.swift */,
 				6DA77F0F1E0802B500D3E3B1 /* NetworkClient.swift */,
 				6DA77F111E08250400D3E3B1 /* Session.swift */,
 				60300C47200F792800AF7A0A /* DynamicCoding.swift */,
@@ -266,7 +266,7 @@
 				60300C48200F792800AF7A0A /* DynamicCoding.swift in Sources */,
 				60300C4C200F7A1E00AF7A0A /* URL+Utilities.swift in Sources */,
 				6DA77F121E08250400D3E3B1 /* Session.swift in Sources */,
-				6DA77F0A1E07E06E00D3E3B1 /* NetworkConfiguration.swift in Sources */,
+				6DA77F0A1E07E06E00D3E3B1 /* Configuration.swift in Sources */,
 				6DA77F061E02FEC200D3E3B1 /* ErrorHandling.swift in Sources */,
 				60300C46200F78DD00AF7A0A /* Pact.swift in Sources */,
 				6DA77F101E0802B500D3E3B1 /* NetworkClient.swift in Sources */,

--- a/MDCNetworking/Configuration.swift
+++ b/MDCNetworking/Configuration.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 public enum SSLPinningMode {
-    case `default`
+    case none
     case certificate
 }
 
@@ -32,7 +32,7 @@ public struct Configuration {
         additionalHeaders: [String: String]? = nil,
         timeout: TimeInterval = 60,
         sessionConfiguration: URLSessionConfiguration = .default,
-        sslPinningMode: SSLPinningMode = .default,
+        sslPinningMode: SSLPinningMode = .none,
         pinnedCertificates: [Data]? = nil
     ) throws {
         
@@ -57,17 +57,16 @@ public struct Configuration {
     
     func request(path: String, parameters: [String: String]?) throws -> URLRequest {
         
-        guard let percentEncodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            throw PathPercentEncodingError()
-        }
-        
         var components = URLComponents()
         
         components.scheme = baseUrl.scheme
         components.host = baseUrl.host
-        components.path = percentEncodedPath
-        components.queryItems = parameters?.flatMap(URLQueryItem.init)
+        components.path = path
         
+        if let parameters = parameters {
+            components.queryItems = parameters.flatMap(URLQueryItem.init)
+        }
+
         guard let requestUrl = components.url else {
             throw UrlConstructionError()
         }

--- a/MDCNetworking/Configuration.swift
+++ b/MDCNetworking/Configuration.swift
@@ -1,5 +1,5 @@
 //
-//  NetworkConfiguration.swift
+//  Configuration.swift
 //  MDCNetworking
 //
 //  Created by Despotovic, Mladen on 19/12/2016.
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public struct NetworkConfiguration {
+public struct Configuration {
     
     public struct UrlConstructionError: Error {}
     public struct PathPercentEncodingError: Error {}

--- a/MDCNetworking/NetworkClient.swift
+++ b/MDCNetworking/NetworkClient.swift
@@ -10,9 +10,35 @@ import Foundation
 
 open class NetworkClient {
     
-    open private (set) var configuration: Configuration
+    open let configuration: Configuration
+    open let sessionProvider: URLSessionProvider?
     
-    public init(configuration: Configuration) {
+    public init(configuration: Configuration, sessionProvider: URLSessionProvider?) {
         self.configuration = configuration
+        self.sessionProvider = sessionProvider
+    }
+    
+    open func session(
+        urlPath: String,
+        method: HTTPMethod = .get,
+        parameters: [String: String]? = nil,
+        body: Data? = nil,
+        session: URLSession? = nil,
+        completion: @escaping ResponseCallback
+    ) -> HTTPSession {
+        
+        let session = HTTPSession(
+            urlPath: urlPath,
+            method: method,
+            parameters: parameters,
+            body: body,
+            configuration: configuration,
+            session: session,
+            completion: completion
+        )
+        
+        session.sessionProvider = sessionProvider
+        
+        return session
     }
 }

--- a/MDCNetworking/NetworkClient.swift
+++ b/MDCNetworking/NetworkClient.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 open class NetworkClient {
-    
+
     open let configuration: Configuration
     open let sessionProvider: URLSessionProvider?
     

--- a/MDCNetworking/NetworkClient.swift
+++ b/MDCNetworking/NetworkClient.swift
@@ -10,9 +10,9 @@ import Foundation
 
 open class NetworkClient {
     
-    open private (set) var configuration: NetworkConfiguration
+    open private (set) var configuration: Configuration
     
-    public init(configuration: NetworkConfiguration) {
+    public init(configuration: Configuration) {
         self.configuration = configuration
     }
 }

--- a/MDCNetworking/Session.swift
+++ b/MDCNetworking/Session.swift
@@ -99,9 +99,6 @@ public class HTTPSession: NSObject, HTTPSessionInterface {
         self.session = session
         self.completion = completion
     }
-}
-
-extension HTTPSession: HTTPSessionInterface {
     
     public func dataTaskCallback() -> (Data?, URLResponse?, Error?) -> Void {
         return { data, response, error in

--- a/MDCNetworking/Session.swift
+++ b/MDCNetworking/Session.swift
@@ -25,7 +25,7 @@ public protocol URLSessionProvider {
 
 public protocol HTTPSessionInterface: URLSessionDelegate {
     
-    var configuration: NetworkConfiguration { get set }
+    var configuration: Configuration { get set }
     var request: Request { get set }
     weak var session: URLSession? { get set }
     var sessionProvider: URLSessionProvider? { get set }
@@ -74,7 +74,7 @@ public struct Request {
 public class HTTPSession: NSObject, HTTPSessionInterface {
     
     public var completion: ResponseCallback
-    public var configuration: NetworkConfiguration
+    public var configuration: Configuration
     public var request: Request
     public var session: URLSession?
     public var sessionProvider: URLSessionProvider? = nil
@@ -84,7 +84,7 @@ public class HTTPSession: NSObject, HTTPSessionInterface {
         method: HTTPMethod = .get,
         parameters: [String: String]? = nil,
         body: Data? = nil,
-        configuration: NetworkConfiguration,
+        configuration: Configuration,
         session: URLSession? = nil,
         completion: @escaping ResponseCallback
     ) {

--- a/MDCNetworking/Session.swift
+++ b/MDCNetworking/Session.swift
@@ -130,6 +130,7 @@ extension HTTPSession: HTTPSessionInterface {
         didReceive challenge: URLAuthenticationChallenge,
         completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void
     ) {
+        
         /*
          For reference: https://github.com/iSECPartners/ssl-conservatory
          */
@@ -149,7 +150,6 @@ extension HTTPSession: HTTPSessionInterface {
                 } else {
                     completionHandler(.useCredential, URLCredential(trust: trust))
                 }
-            
             default:
                 completionHandler(.performDefaultHandling, nil)
         }

--- a/MDCNetworkingTests/ClientTests.swift
+++ b/MDCNetworkingTests/ClientTests.swift
@@ -13,8 +13,8 @@ class ClientTests: XCTestCase {
     
     func testClientInitialization() {
         // Test with configuration
-        let session1 = NetworkConfiguration(host: "https://somehost")
-        let client1 = NetworkClient(configuration: session1!)
+        let session1 = try? Configuration(scheme: "https", host: "somehost")
+        let client1 = NetworkClient(configuration: session1!, sessionProvider: nil)
         XCTAssertNotNil(client1)
         XCTAssertNotNil(client1.configuration)
     }

--- a/MDCNetworkingTests/ConfigurationTests.swift
+++ b/MDCNetworkingTests/ConfigurationTests.swift
@@ -24,23 +24,23 @@ class ConfigurationTests: XCTestCase {
     func testInstantiation() {
         
         // Designated initializer
-        let session1 = NetworkConfiguration(host: "https://somehost")
-        XCTAssertEqual(session1?.host.description, "https://somehost")
+        let session1 = try? Configuration(scheme: "https", host: "somehost")
+        XCTAssertEqual(session1?.baseUrl.host?.description, "somehost")
         
         // Additional headers
-        let session2 = NetworkConfiguration(host: "https://somehost",
+        let session2 = try? Configuration(scheme: "https", host: "somehost",
                                             additionalHeaders: ["Accept-Encoding":"gzip", "Content-Type":"application/json"])
         XCTAssertEqual(session2?.additionalHeaders.count, 2)
         
         // Timeout
-        let session3 = NetworkConfiguration(host: "https://somehost",
+        let session3 = try? Configuration(scheme: "https", host: "somehost",
                                             additionalHeaders: ["Accept-Encoding":"gzip", "Content-Type":"application/json"], timeout: 20)
         XCTAssertEqual(session3?.timeout, 20)
         
         // Session configuration
         let configuration = URLSessionConfiguration.default
         configuration.timeoutIntervalForRequest = 30
-        let session4 = NetworkConfiguration(host: "https://somehost",
+        let session4 = try? Configuration(scheme: "https", host: "somehost",
                                             additionalHeaders: ["Accept-Encoding":"gzip", "Content-Type":"application/json"],
                                             timeout: 20,
                                             sessionConfiguration: configuration)
@@ -50,20 +50,20 @@ class ConfigurationTests: XCTestCase {
     func testURLRequest() {
         
         // basic request
-        var session = NetworkConfiguration(host: "https://somehost")
-        var request = try! session!.request(path: "path", parameters: nil)
+        var session = try? Configuration(scheme: "https", host: "somehost")
+        var request = try! session!.request(path: "/path", parameters: nil)
 
         XCTAssertEqual(request.description, "https://somehost/path")
         
         // Single parameter
-        session = NetworkConfiguration(host: "https://somehost")
-        request = try! session!.request(path: "path", parameters: ["parameter": "value"])
+        session = try? Configuration(scheme: "https", host: "somehost")
+        request = try! session!.request(path: "/path", parameters: ["parameter": "value"])
         
         XCTAssertEqual(request.description, "https://somehost/path?parameter=value")
         
         // Two parameters
-        session = NetworkConfiguration(host: "https://somehost")
-        request = try! session!.request(path: "path", parameters: ["parameter": "value", "parameter1": "value1"])
+        session = try? Configuration(scheme: "https", host: "somehost")
+        request = try! session!.request(path: "/path", parameters: ["parameter": "value", "parameter1": "value1"])
         
         XCTAssertEqual(request.description, "https://somehost/path?parameter=value&parameter1=value1")
     }

--- a/MDCNetworkingTests/SessionTests.swift
+++ b/MDCNetworkingTests/SessionTests.swift
@@ -14,7 +14,7 @@ class SessionTests: XCTestCase {
     func testInitialising() {
     
         // Test with default GET method
-        let configuration = NetworkConfiguration(host: "http://api.timezonedb.com/")
+        let configuration = try? Configuration(scheme: "http", host: "api.timezonedb.com")
         let session1 = HTTPSession(
             urlPath: "https://somehost",
             configuration: configuration!
@@ -32,7 +32,7 @@ class SessionTests: XCTestCase {
         
         // Prepare without Configuration object set
         let expectationForTest = expectation(description: "test")
-        let configuration = NetworkConfiguration(host: "http://api.timezonedb.com/")
+        let configuration = try? Configuration(scheme: "http", host: "api.timezonedb.com")
         let parameters = ["key": "1S2RMN6YBMYA", "country": "GB", "format": "json"]
         
         // Execute and test
@@ -69,7 +69,7 @@ class SessionTests: XCTestCase {
         
         // Prepare without Configuration object set
         let expectationForTest = expectation(description: "test")
-        let configuration = NetworkConfiguration(host: "http://api.timezonedb.com/")
+        let configuration = try? Configuration(scheme: "http", host: "api.timezonedb.com")
         let parameters = ["key": "1S2RMN6YBMYA", "format": "json", "country": "GB"]
         
         // Prepare stubbed session
@@ -115,7 +115,7 @@ class SessionTests: XCTestCase {
         
         // Prepare without Configuration object set
         let expectationForTest = expectation(description: "test")
-        let configuration = NetworkConfiguration(host: "http://api.timezonedb.com/")
+        let configuration = try? Configuration(scheme: "http", host: "api.timezonedb.com")
         let parameters = ["key": "1S2RMN6YBMYA", "format": "json", "country": "GB"]
         
         // Prepare stubbed session
@@ -166,7 +166,7 @@ class SessionTests: XCTestCase {
         
         // Prepare without Configuration object set
         let expectationForTest = expectation(description: "test")
-        let configuration = NetworkConfiguration(host: "http://api.timezonedb.com/")
+        let configuration = try? Configuration(scheme: "http", host: "api.timezonedb.com")
         let parameters = ["key": "1S2RMN6YBMYA", "format": "json", "country": "GB"]
         
         // Prepare stubbed session


### PR DESCRIPTION
Added certificate pinning switch to `Configuration`

Changed the authentication challenge logic to:

1) Perform SSL certificate chain validation by default on authentication challenge
2) If:
    - Certificate pinning is on and we have no certificates pinned, the authentication challenge is cancelled.
    - Certificate pinning is on and we have certificates pinned, we're performing matching of leaf certificate to our pinned certificates. If it matches, we accept credential, if it doesn't, we cancel the connection.
    - Certificate pinning is off, we accept provided credential if chain validation succeeds, cancel the challenge if it fails.
