### PR TITLE
Feature/pact network client

### DIFF
--- a/MDCNetworking.xcodeproj/project.pbxproj
+++ b/MDCNetworking.xcodeproj/project.pbxproj
@@ -17,7 +17,7 @@
 		6DA77EFC1E02FEA800D3E3B1 /* MDCNetworking.h in Headers */ = {isa = PBXBuildFile; fileRef = 6DA77EEE1E02FEA800D3E3B1 /* MDCNetworking.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		6DA77F061E02FEC200D3E3B1 /* ErrorHandling.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DA77F051E02FEC200D3E3B1 /* ErrorHandling.swift */; };
 		6DA77F081E0404B300D3E3B1 /* NetworkingErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DA77F071E0404B300D3E3B1 /* NetworkingErrorTests.swift */; };
-		6DA77F0A1E07E06E00D3E3B1 /* NetworkConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DA77F091E07E06E00D3E3B1 /* NetworkConfiguration.swift */; };
+		6DA77F0A1E07E06E00D3E3B1 /* Configuration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DA77F091E07E06E00D3E3B1 /* Configuration.swift */; };
 		6DA77F0C1E07F81E00D3E3B1 /* ConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DA77F0B1E07F81E00D3E3B1 /* ConfigurationTests.swift */; };
 		6DA77F0E1E08022F00D3E3B1 /* ClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DA77F0D1E08022F00D3E3B1 /* ClientTests.swift */; };
 		6DA77F101E0802B500D3E3B1 /* NetworkClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DA77F0F1E0802B500D3E3B1 /* NetworkClient.swift */; };
@@ -54,7 +54,7 @@
 		6DA77EFB1E02FEA800D3E3B1 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		6DA77F051E02FEC200D3E3B1 /* ErrorHandling.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ErrorHandling.swift; sourceTree = "<group>"; };
 		6DA77F071E0404B300D3E3B1 /* NetworkingErrorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NetworkingErrorTests.swift; sourceTree = "<group>"; };
-		6DA77F091E07E06E00D3E3B1 /* NetworkConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NetworkConfiguration.swift; sourceTree = "<group>"; };
+		6DA77F091E07E06E00D3E3B1 /* Configuration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Configuration.swift; sourceTree = "<group>"; };
 		6DA77F0B1E07F81E00D3E3B1 /* ConfigurationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ConfigurationTests.swift; sourceTree = "<group>"; };
 		6DA77F0D1E08022F00D3E3B1 /* ClientTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ClientTests.swift; sourceTree = "<group>"; };
 		6DA77F0F1E0802B500D3E3B1 /* NetworkClient.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NetworkClient.swift; sourceTree = "<group>"; };
@@ -121,7 +121,7 @@
 				6DA77EEE1E02FEA800D3E3B1 /* MDCNetworking.h */,
 				6DA77EEF1E02FEA800D3E3B1 /* Info.plist */,
 				6DA77F051E02FEC200D3E3B1 /* ErrorHandling.swift */,
-				6DA77F091E07E06E00D3E3B1 /* NetworkConfiguration.swift */,
+				6DA77F091E07E06E00D3E3B1 /* Configuration.swift */,
 				6DA77F0F1E0802B500D3E3B1 /* NetworkClient.swift */,
 				6DA77F111E08250400D3E3B1 /* Session.swift */,
 				60300C47200F792800AF7A0A /* DynamicCoding.swift */,
@@ -266,7 +266,7 @@
 				60300C48200F792800AF7A0A /* DynamicCoding.swift in Sources */,
 				60300C4C200F7A1E00AF7A0A /* URL+Utilities.swift in Sources */,
 				6DA77F121E08250400D3E3B1 /* Session.swift in Sources */,
-				6DA77F0A1E07E06E00D3E3B1 /* NetworkConfiguration.swift in Sources */,
+				6DA77F0A1E07E06E00D3E3B1 /* Configuration.swift in Sources */,
 				6DA77F061E02FEC200D3E3B1 /* ErrorHandling.swift in Sources */,
 				60300C46200F78DD00AF7A0A /* Pact.swift in Sources */,
 				6DA77F101E0802B500D3E3B1 /* NetworkClient.swift in Sources */,

--- a/MDCNetworking.xcodeproj/project.pbxproj
+++ b/MDCNetworking.xcodeproj/project.pbxproj
@@ -7,11 +7,12 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		600D65872040533000C7174D /* PactNetworkClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 600D65862040533000C7174D /* PactNetworkClient.swift */; };
 		60300C46200F78DD00AF7A0A /* Pact.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60300C45200F78DD00AF7A0A /* Pact.swift */; };
 		60300C48200F792800AF7A0A /* DynamicCoding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60300C47200F792800AF7A0A /* DynamicCoding.swift */; };
 		60300C4A200F797700AF7A0A /* PactStubbedURLSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60300C49200F797700AF7A0A /* PactStubbedURLSession.swift */; };
 		60300C4C200F7A1E00AF7A0A /* URL+Utilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60300C4B200F7A1E00AF7A0A /* URL+Utilities.swift */; };
-		609E824A2016004F004B7A7C /* PactStubProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 609E82492016004F004B7A7C /* PactStubProvider.swift */; };
+		609E824A2016004F004B7A7C /* PactSessionProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 609E82492016004F004B7A7C /* PactSessionProvider.swift */; };
 		6D398AFC1E254B7F005A67E7 /* Test1.json in Resources */ = {isa = PBXBuildFile; fileRef = 6D398AFB1E254B7F005A67E7 /* Test1.json */; };
 		6DA77EF51E02FEA800D3E3B1 /* MDCNetworking.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6DA77EEB1E02FEA800D3E3B1 /* MDCNetworking.framework */; };
 		6DA77EFC1E02FEA800D3E3B1 /* MDCNetworking.h in Headers */ = {isa = PBXBuildFile; fileRef = 6DA77EEE1E02FEA800D3E3B1 /* MDCNetworking.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -41,11 +42,12 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		600D65862040533000C7174D /* PactNetworkClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PactNetworkClient.swift; sourceTree = "<group>"; };
 		60300C45200F78DD00AF7A0A /* Pact.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Pact.swift; sourceTree = "<group>"; };
 		60300C47200F792800AF7A0A /* DynamicCoding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DynamicCoding.swift; sourceTree = "<group>"; };
 		60300C49200F797700AF7A0A /* PactStubbedURLSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PactStubbedURLSession.swift; sourceTree = "<group>"; };
 		60300C4B200F7A1E00AF7A0A /* URL+Utilities.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URL+Utilities.swift"; sourceTree = "<group>"; };
-		609E82492016004F004B7A7C /* PactStubProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PactStubProvider.swift; sourceTree = "<group>"; };
+		609E82492016004F004B7A7C /* PactSessionProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PactSessionProvider.swift; sourceTree = "<group>"; };
 		6D398AFB1E254B7F005A67E7 /* Test1.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = Test1.json; sourceTree = "<group>"; };
 		6DA77EEB1E02FEA800D3E3B1 /* MDCNetworking.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = MDCNetworking.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		6DA77EEE1E02FEA800D3E3B1 /* MDCNetworking.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MDCNetworking.h; sourceTree = "<group>"; };
@@ -91,7 +93,8 @@
 			children = (
 				60300C45200F78DD00AF7A0A /* Pact.swift */,
 				60300C49200F797700AF7A0A /* PactStubbedURLSession.swift */,
-				609E82492016004F004B7A7C /* PactStubProvider.swift */,
+				609E82492016004F004B7A7C /* PactSessionProvider.swift */,
+				600D65862040533000C7174D /* PactNetworkClient.swift */,
 			);
 			path = Pact;
 			sourceTree = "<group>";
@@ -270,8 +273,9 @@
 				6DA77F061E02FEC200D3E3B1 /* ErrorHandling.swift in Sources */,
 				60300C46200F78DD00AF7A0A /* Pact.swift in Sources */,
 				6DA77F101E0802B500D3E3B1 /* NetworkClient.swift in Sources */,
-				609E824A2016004F004B7A7C /* PactStubProvider.swift in Sources */,
+				609E824A2016004F004B7A7C /* PactSessionProvider.swift in Sources */,
 				6DA77F1E1E1FF34100D3E3B1 /* StubbedURLSession.swift in Sources */,
+				600D65872040533000C7174D /* PactNetworkClient.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/MDCNetworking/Configuration.swift
+++ b/MDCNetworking/Configuration.swift
@@ -21,7 +21,6 @@ public struct Configuration {
 
     let baseUrl: URL
     let additionalHeaders: [String: String]
-    let timeout: TimeInterval
     let sessionConfiguration: URLSessionConfiguration
     let sslPinningMode: SSLPinningMode
     let pinnedCertificates: [Data]?
@@ -30,7 +29,6 @@ public struct Configuration {
         scheme: String,
         host: String,
         additionalHeaders: [String: String]? = nil,
-        timeout: TimeInterval = 60,
         sessionConfiguration: URLSessionConfiguration = .default,
         sslPinningMode: SSLPinningMode = .default,
         pinnedCertificates: [Data]? = nil
@@ -48,25 +46,27 @@ public struct Configuration {
         self.baseUrl = baseUrl
         
         self.additionalHeaders = additionalHeaders ?? [:]
-        self.timeout = timeout
         self.sessionConfiguration = sessionConfiguration
-        self.sessionConfiguration.timeoutIntervalForRequest = timeout
         self.sslPinningMode = sslPinningMode
         self.pinnedCertificates = pinnedCertificates
     }
     
-    func request(path: String, parameters: [String: String]?) throws -> URLRequest {
+    func request(path: String, parameters: [String: String]? = nil) throws -> URLRequest {
+
+        let correctedPath: String
         
-        guard let percentEncodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            throw PathPercentEncodingError()
+        if path.prefix(1) != "/" {
+            correctedPath = "/" + path
+        } else {
+            correctedPath = path
         }
         
         var components = URLComponents()
         
         components.scheme = baseUrl.scheme
         components.host = baseUrl.host
-        components.path = percentEncodedPath
-        components.queryItems = parameters?.flatMap(URLQueryItem.init)
+        components.path = correctedPath
+        components.queryItems = parameters?.flatMap(URLQueryItem.init) ?? []
         
         guard let requestUrl = components.url else {
             throw UrlConstructionError()

--- a/MDCNetworking/Configuration.swift
+++ b/MDCNetworking/Configuration.swift
@@ -66,7 +66,9 @@ public struct Configuration {
         components.scheme = baseUrl.scheme
         components.host = baseUrl.host
         components.path = correctedPath
-        components.queryItems = parameters?.flatMap(URLQueryItem.init) ?? []
+        if let parameters = parameters {
+            components.queryItems = parameters.flatMap(URLQueryItem.init)
+        }
         
         guard let requestUrl = components.url else {
             throw UrlConstructionError()

--- a/MDCNetworking/Configuration.swift
+++ b/MDCNetworking/Configuration.swift
@@ -1,5 +1,5 @@
 //
-//  NetworkConfiguration.swift
+//  Configuration.swift
 //  MDCNetworking
 //
 //  Created by Despotovic, Mladen on 19/12/2016.
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public struct NetworkConfiguration {
+public struct Configuration {
     
     public struct UrlConstructionError: Error {}
     public struct PathPercentEncodingError: Error {}

--- a/MDCNetworking/NetworkClient.swift
+++ b/MDCNetworking/NetworkClient.swift
@@ -10,9 +10,35 @@ import Foundation
 
 open class NetworkClient {
     
-    open private (set) var configuration: Configuration
+    open let configuration: Configuration
+    open let sessionProvider: URLSessionProvider?
     
-    public init(configuration: Configuration) {
+    public init(configuration: Configuration, sessionProvider: URLSessionProvider?) {
         self.configuration = configuration
+        self.sessionProvider = sessionProvider
+    }
+    
+    open func session(
+        urlPath: String,
+        method: HTTPMethod = .get,
+        parameters: [String: String]? = nil,
+        body: Data? = nil,
+        session: URLSession? = nil,
+        completion: @escaping ResponseCallback
+    ) -> HTTPSession {
+        
+        let session = HTTPSession(
+            urlPath: urlPath,
+            method: method,
+            parameters: parameters,
+            body: body,
+            configuration: configuration,
+            session: session,
+            completion: completion
+        )
+        
+        session.sessionProvider = sessionProvider
+        
+        return session
     }
 }

--- a/MDCNetworking/NetworkClient.swift
+++ b/MDCNetworking/NetworkClient.swift
@@ -13,7 +13,7 @@ open class NetworkClient {
     open let configuration: Configuration
     open let sessionProvider: URLSessionProvider?
     
-    public init(configuration: Configuration, sessionProvider: URLSessionProvider?) {
+    public init(configuration: Configuration, sessionProvider: URLSessionProvider? = nil) {
         self.configuration = configuration
         self.sessionProvider = sessionProvider
     }

--- a/MDCNetworking/NetworkClient.swift
+++ b/MDCNetworking/NetworkClient.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 open class NetworkClient {
-    
+
     open let configuration: Configuration
     open let sessionProvider: URLSessionProvider?
     

--- a/MDCNetworking/NetworkClient.swift
+++ b/MDCNetworking/NetworkClient.swift
@@ -10,9 +10,9 @@ import Foundation
 
 open class NetworkClient {
     
-    open private (set) var configuration: NetworkConfiguration
+    open private (set) var configuration: Configuration
     
-    public init(configuration: NetworkConfiguration) {
+    public init(configuration: Configuration) {
         self.configuration = configuration
     }
 }

--- a/MDCNetworking/NetworkClient.swift
+++ b/MDCNetworking/NetworkClient.swift
@@ -20,17 +20,14 @@ public protocol NetworkClientInterface {
     ) throws -> HTTPSession
 }
 
-open class NetworkClient {
+open class NetworkClient: NetworkClientInterface {
 
     open let configuration: Configuration
     
     public init(configuration: Configuration) {
         self.configuration = configuration
     }
-}
 
-extension NetworkClient: NetworkClientInterface {
-    
     /**
      * Creates a HTTP session based on provided configuration.
      */

--- a/MDCNetworking/NetworkClient.swift
+++ b/MDCNetworking/NetworkClient.swift
@@ -8,27 +8,44 @@
 
 import Foundation
 
+public protocol NetworkClientInterface {
+    func session(
+        path: String,
+        method: HTTPMethod,
+        parameters: [String: String]?,
+        body: Data?,
+        additionalHeaderFields: [String: String]?,
+        session: URLSession?,
+        completion: @escaping ResponseCallback
+    ) throws -> HTTPSession
+}
+
 open class NetworkClient {
 
     open let configuration: Configuration
-    open let sessionProvider: URLSessionProvider?
     
-    public init(configuration: Configuration, sessionProvider: URLSessionProvider? = nil) {
+    public init(configuration: Configuration) {
         self.configuration = configuration
-        self.sessionProvider = sessionProvider
     }
+}
+
+extension NetworkClient: NetworkClientInterface {
     
+    /**
+     * Creates a HTTP session based on provided configuration.
+     */
     open func session(
-        urlPath: String,
+        path: String,
         method: HTTPMethod = .get,
         parameters: [String: String]? = nil,
         body: Data? = nil,
+        additionalHeaderFields: [String: String]? = nil,
         session: URLSession? = nil,
         completion: @escaping ResponseCallback
     ) -> HTTPSession {
         
         let session = HTTPSession(
-            urlPath: urlPath,
+            path: path,
             method: method,
             parameters: parameters,
             body: body,
@@ -37,7 +54,7 @@ open class NetworkClient {
             completion: completion
         )
         
-        session.sessionProvider = sessionProvider
+        session.request.additionalHeaderFields = additionalHeaderFields
         
         return session
     }

--- a/MDCNetworking/NetworkClient.swift
+++ b/MDCNetworking/NetworkClient.swift
@@ -39,7 +39,7 @@ open class NetworkClient: NetworkClientInterface {
         additionalHeaderFields: [String: String]? = nil,
         session: URLSession? = nil,
         completion: @escaping ResponseCallback
-    ) -> HTTPSession {
+    ) throws -> HTTPSession {
         
         let session = HTTPSession(
             path: path,

--- a/MDCNetworking/Pact/PactNetworkClient.swift
+++ b/MDCNetworking/Pact/PactNetworkClient.swift
@@ -24,12 +24,17 @@ public protocol InteractionStubbable {
 }
 
 /**
+ * Network client with interface for adding stubbed interactions.
+ */
+public protocol PactNetworkClientInterface: NetworkClientInterface, InteractionStubbable {}
+
+/**
  * Network client with the possibility of stubbing selected request responses using Pact interactions. Gathers all
  * interactions into a Pact model ready for serialization and sending to a contract broker or repository.
  *
  * [Pact specification can be found here](https://github.com/pact-foundation/pact-specification/tree/version-2).
  */
-open class PactNetworkClient: NetworkClientInterface, InteractionStubbable {
+open class PactNetworkClient: PactNetworkClientInterface {
     
     open let configuration: Configuration
     open let sessionProvider: PactSessionProvider

--- a/MDCNetworking/Pact/PactNetworkClient.swift
+++ b/MDCNetworking/Pact/PactNetworkClient.swift
@@ -59,7 +59,7 @@ open class PactNetworkClient: NetworkClientInterface, InteractionStubbable {
         additionalHeaderFields: [String: String]? = nil,
         session: URLSession? = nil,
         completion: @escaping ResponseCallback
-    ) -> HTTPSession {
+    ) throws -> HTTPSession {
         
         let session = HTTPSession(
             path: path,

--- a/MDCNetworking/Pact/PactNetworkClient.swift
+++ b/MDCNetworking/Pact/PactNetworkClient.swift
@@ -29,7 +29,7 @@ public protocol InteractionStubbable {
  *
  * [Pact specification can be found here](https://github.com/pact-foundation/pact-specification/tree/version-2).
  */
-open class PactNetworkClient {
+open class PactNetworkClient: NetworkClientInterface, InteractionStubbable {
     
     open let configuration: Configuration
     open let sessionProvider: PactSessionProvider
@@ -38,9 +38,6 @@ open class PactNetworkClient {
         self.configuration = configuration
         self.sessionProvider = sessionProvider
     }
-}
-
-extension PactNetworkClient: NetworkClientInterface {
     
     /**
      * Creates a `HTTPSession` based on provided `Configuration` which response will be stubbed if matching
@@ -79,9 +76,6 @@ extension PactNetworkClient: NetworkClientInterface {
         
         return session
     }
-}
-
-extension PactNetworkClient: InteractionStubbable {
     
     /**
      * Stubs the response for selected request.

--- a/MDCNetworking/Pact/PactNetworkClient.swift
+++ b/MDCNetworking/Pact/PactNetworkClient.swift
@@ -1,0 +1,118 @@
+//
+//  PactNetworkClient.swift
+//  MDCNetworking
+//
+//  Created by Bartomiej Nowak on 23/02/2018.
+//  Copyright © 2018 Despotovic, Mladen. All rights reserved.
+//
+
+import Foundation
+
+/**
+ * Adds stubbing capabilities to an object based on Pact specification.
+ */
+public protocol InteractionStubbable {
+    func addStubbedInteraction(
+        providerState: String,
+        description: String,
+        method: HTTPMethod,
+        path: String,
+        parameters: [String: String]?,
+        responseStatus: Int,
+        responseBody: Any?
+    ) throws
+}
+
+/**
+ * Network client with the possibility of stubbing selected request responses using Pact interactions. Gathers all
+ * interactions into a Pact model ready for serialization and sending to a contract broker or repository.
+ *
+ * [Pact specification can be found here](https://github.com/pact-foundation/pact-specification/tree/version-2).
+ */
+open class PactNetworkClient {
+    
+    open let configuration: Configuration
+    open let sessionProvider: PactSessionProvider
+    
+    public init(configuration: Configuration, sessionProvider: PactSessionProvider) {
+        self.configuration = configuration
+        self.sessionProvider = sessionProvider
+    }
+}
+
+extension PactNetworkClient: NetworkClientInterface {
+    
+    /**
+     * Creates a `HTTPSession` based on provided `Configuration` which response will be stubbed if matching
+     * request/response pair can be found in the `PactSessionProvider`.
+     *
+     * - parameter path: String describing the path. Added to the schema/host provided by `Configuration` model.
+     * - parameter method: HTTP method.
+     * - parameter parameters: Query items to be serialized into the request URL.
+     * - parameter body: Contents of the body sent with the request.
+     * - parameter additionalHeaderFields: Additional header fields to be included with the request. Will override header fields set from `Configuration` model.
+     * - parameter session: Overrides the `URLSession` used by the session.
+     * - parameter completion: Callback executed when receiving a response.
+     */
+    open func session(
+        path: String,
+        method: HTTPMethod = .get,
+        parameters: [String : String]? = nil,
+        body: Data? = nil,
+        additionalHeaderFields: [String: String]? = nil,
+        session: URLSession? = nil,
+        completion: @escaping ResponseCallback
+    ) -> HTTPSession {
+        
+        let session = HTTPSession(
+            path: path,
+            method: method,
+            parameters: parameters,
+            body: body,
+            configuration: configuration,
+            session: session,
+            completion: completion
+        )
+        
+        session.request.additionalHeaderFields = additionalHeaderFields
+        session.sessionProvider = sessionProvider
+        
+        return session
+    }
+}
+
+extension PactNetworkClient: InteractionStubbable {
+    
+    /**
+     * Stubs the response for selected request.
+     *
+     * - parameter providerState: String describing the provider's context required for the interaction.
+     * [See pact specification](https://docs.pact.io/documentation/provider_states.html).
+     * - parameter description: Short description of the interaction, e.g. _get all highlights for current user_
+     * - parameter method: HTTP method name.
+     * - parameter path: Request URL path.
+     * - parameter parameters: Request parameters.
+     * - parameter responseStatus: HTTP response status.
+     * - parameter responseBody: HTTP response body.
+     */
+    open func addStubbedInteraction(
+        providerState: String,
+        description: String,
+        method: HTTPMethod,
+        path: String,
+        parameters: [String: String]? = nil,
+        responseStatus: Int,
+        responseBody: Any? = nil
+    ) throws {
+        
+        try sessionProvider.generateInteraction(
+            providerState: providerState,
+            description: description,
+            method: method,
+            path: path,
+            parameters: parameters,
+            responseStatus: responseStatus,
+            responseBody: responseBody
+        )
+    }
+}

--- a/MDCNetworking/Pact/PactSessionProvider.swift
+++ b/MDCNetworking/Pact/PactSessionProvider.swift
@@ -1,5 +1,5 @@
 //
-//  PactStubProvider.swift
+//  PactSessionProvider.swift
 //  MDCNetworking
 //
 //  Created by Bartomiej Nowak on 22/01/2018.

--- a/MDCNetworking/Session.swift
+++ b/MDCNetworking/Session.swift
@@ -25,7 +25,7 @@ public protocol URLSessionProvider {
 
 public protocol HTTPSessionInterface: URLSessionDelegate {
     
-    var configuration: NetworkConfiguration { get set }
+    var configuration: Configuration { get set }
     var request: Request { get set }
     weak var session: URLSession? { get set }
     var sessionProvider: URLSessionProvider? { get set }
@@ -74,7 +74,7 @@ public struct Request {
 public class HTTPSession: NSObject, HTTPSessionInterface {
     
     public var completion: ResponseCallback
-    public var configuration: NetworkConfiguration
+    public var configuration: Configuration
     public var request: Request
     public var session: URLSession?
     public var sessionProvider: URLSessionProvider? = nil
@@ -84,7 +84,7 @@ public class HTTPSession: NSObject, HTTPSessionInterface {
         method: HTTPMethod = .get,
         parameters: [String: String]? = nil,
         body: Data? = nil,
-        configuration: NetworkConfiguration,
+        configuration: Configuration,
         session: URLSession? = nil,
         completion: @escaping ResponseCallback
     ) {

--- a/MDCNetworking/Session.swift
+++ b/MDCNetworking/Session.swift
@@ -73,7 +73,7 @@ public struct Request {
     public var body: Data?
 }
 
-public class HTTPSession: NSObject {
+public class HTTPSession: NSObject, HTTPSessionInterface {
     
     public var completion: ResponseCallback
     public var configuration: Configuration
@@ -102,9 +102,6 @@ public class HTTPSession: NSObject {
         self.session = session
         self.completion = completion
     }
-}
-
-extension HTTPSession: HTTPSessionInterface {
     
     public func dataTaskCallback() -> (Data?, URLResponse?, Error?) -> Void {
         return { data, response, error in
@@ -133,7 +130,6 @@ extension HTTPSession: HTTPSessionInterface {
         didReceive challenge: URLAuthenticationChallenge,
         completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void
     ) {
-        
         /*
          For reference: https://github.com/iSECPartners/ssl-conservatory
          */

--- a/MDCNetworking/Session.swift
+++ b/MDCNetworking/Session.swift
@@ -39,7 +39,7 @@ public protocol HTTPSessionInterface: URLSessionDelegate {
 extension HTTPSessionInterface {
     
     public func start() throws {
-        var urlRequest = try configuration.request(path: request.urlPath, parameters: request.parameters)
+        var urlRequest = try configuration.request(path: request.path, parameters: request.parameters)
 
         urlRequest.httpMethod = request.method.rawValue
         urlRequest.httpBody = request.body
@@ -51,6 +51,8 @@ extension HTTPSessionInterface {
                 delegateQueue: nil
             )
         }
+        
+        request.additionalHeaderFields?.forEach { urlRequest.addValue($1, forHTTPHeaderField: $0) }
         
         session?.dataTask(with: urlRequest, completionHandler: dataTaskCallback()).resume()
     }
@@ -64,9 +66,9 @@ extension HTTPSessionInterface {
 }
 
 public struct Request {
-    public var urlPath: String
+    public var path: String
     public var method: HTTPMethod
-    public var additionalHeaders: [String: String]
+    public var additionalHeaderFields: [String: String]?
     public var parameters: [String: String]?
     public var body: Data?
 }
@@ -80,18 +82,19 @@ public class HTTPSession: NSObject {
     public var sessionProvider: URLSessionProvider? = nil
     
     public required init(
-        urlPath: String,
+        path: String,
         method: HTTPMethod = .get,
         parameters: [String: String]? = nil,
         body: Data? = nil,
         configuration: Configuration,
+        additionalHeaderFields: [String: String]? = nil,
         session: URLSession? = nil,
         completion: @escaping ResponseCallback
     ) {
         self.request = Request(
-            urlPath: urlPath,
+            path: path,
             method: method,
-            additionalHeaders: [:],
+            additionalHeaderFields: additionalHeaderFields,
             parameters: parameters,
             body: body
         )

--- a/MDCNetworking/Session.swift
+++ b/MDCNetworking/Session.swift
@@ -130,6 +130,7 @@ extension HTTPSession: HTTPSessionInterface {
         didReceive challenge: URLAuthenticationChallenge,
         completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void
     ) {
+        
         /*
          For reference: https://github.com/iSECPartners/ssl-conservatory
          */
@@ -149,7 +150,6 @@ extension HTTPSession: HTTPSessionInterface {
                 } else {
                     completionHandler(.useCredential, URLCredential(trust: trust))
                 }
-            
             default:
                 completionHandler(.performDefaultHandling, nil)
         }

--- a/MDCNetworking/Session.swift
+++ b/MDCNetworking/Session.swift
@@ -71,7 +71,7 @@ public struct Request {
     public var body: Data?
 }
 
-public class HTTPSession: NSObject, HTTPSessionInterface {
+public class HTTPSession: NSObject {
     
     public var completion: ResponseCallback
     public var configuration: Configuration

--- a/MDCNetworkingTests/ClientTests.swift
+++ b/MDCNetworkingTests/ClientTests.swift
@@ -13,7 +13,7 @@ class ClientTests: XCTestCase {
     
     func testClientInitialization() {
         // Test with configuration
-        let session1 = NetworkConfiguration(host: "https://somehost")
+        let session1 = try? Configuration(scheme: "https", host: "somehost")
         let client1 = NetworkClient(configuration: session1!)
         XCTAssertNotNil(client1)
         XCTAssertNotNil(client1.configuration)

--- a/MDCNetworkingTests/SessionTests.swift
+++ b/MDCNetworkingTests/SessionTests.swift
@@ -14,7 +14,7 @@ class SessionTests: XCTestCase {
     func testInitialising() {
     
         // Test with default GET method
-        let configuration = NetworkConfiguration(host: "http://api.timezonedb.com/")
+        let configuration = try? Configuration(scheme: "http", host: "api.timezonedb.com")
         let session1 = HTTPSession(
             urlPath: "https://somehost",
             configuration: configuration!
@@ -32,7 +32,7 @@ class SessionTests: XCTestCase {
         
         // Prepare without Configuration object set
         let expectationForTest = expectation(description: "test")
-        let configuration = NetworkConfiguration(host: "http://api.timezonedb.com/")
+        let configuration = try? Configuration(scheme: "http", host: "api.timezonedb.com")
         let parameters = ["key": "1S2RMN6YBMYA", "country": "GB", "format": "json"]
         
         // Execute and test
@@ -69,7 +69,7 @@ class SessionTests: XCTestCase {
         
         // Prepare without Configuration object set
         let expectationForTest = expectation(description: "test")
-        let configuration = NetworkConfiguration(host: "http://api.timezonedb.com/")
+        let configuration = try? Configuration(scheme: "http", host: "api.timezonedb.com")
         let parameters = ["key": "1S2RMN6YBMYA", "format": "json", "country": "GB"]
         
         // Prepare stubbed session
@@ -115,7 +115,7 @@ class SessionTests: XCTestCase {
         
         // Prepare without Configuration object set
         let expectationForTest = expectation(description: "test")
-        let configuration = NetworkConfiguration(host: "http://api.timezonedb.com/")
+        let configuration = try? Configuration(scheme: "http", host: "api.timezonedb.com")
         let parameters = ["key": "1S2RMN6YBMYA", "format": "json", "country": "GB"]
         
         // Prepare stubbed session
@@ -166,7 +166,7 @@ class SessionTests: XCTestCase {
         
         // Prepare without Configuration object set
         let expectationForTest = expectation(description: "test")
-        let configuration = NetworkConfiguration(host: "http://api.timezonedb.com/")
+        let configuration = try? Configuration(scheme: "http", host: "api.timezonedb.com")
         let parameters = ["key": "1S2RMN6YBMYA", "format": "json", "country": "GB"]
         
         // Prepare stubbed session

--- a/MDCNetworkingTests/SessionTests.swift
+++ b/MDCNetworkingTests/SessionTests.swift
@@ -16,7 +16,7 @@ class SessionTests: XCTestCase {
         // Test with default GET method
         let configuration = try? Configuration(scheme: "http", host: "api.timezonedb.com")
         let session1 = HTTPSession(
-            urlPath: "https://somehost",
+            path: "https://somehost",
             configuration: configuration!
         ) { _, _, _, _ in }
         
@@ -37,7 +37,7 @@ class SessionTests: XCTestCase {
         
         // Execute and test
         let session1 = HTTPSession(
-            urlPath: "/v2/list-time-zone",
+            path: "/v2/list-time-zone",
             method: .get,
             parameters: parameters,
             configuration: configuration!
@@ -82,7 +82,7 @@ class SessionTests: XCTestCase {
         
         // Execute and test
         let session1 = HTTPSession(
-            urlPath: "/v2/list-time-zone",
+            path: "/v2/list-time-zone",
             method: .get,
             parameters: parameters,
             configuration: configuration!,
@@ -133,7 +133,7 @@ class SessionTests: XCTestCase {
         
         // Execute and test
         let session1 = HTTPSession(
-            urlPath: "/v2/list-time-zone",
+            path: "/v2/list-time-zone",
             method: .get,
             parameters: parameters,
             configuration: configuration!,
@@ -180,7 +180,7 @@ class SessionTests: XCTestCase {
         
         // Execute and test
         let session1 = HTTPSession(
-            urlPath: "/v2/list-time-zone",
+            path: "/v2/list-time-zone",
             method: .get,
             parameters: parameters,
             configuration: configuration!,


### PR DESCRIPTION
- Added `PactNetworkClient`
- Fixed `additionalHeaderFields` which weren't added to the `URLRequest`
- Fixed the `Configuration.request` URL generation, which deserialized an empty query items list to a single question mark, as in `protocol://host/path?`
- Various interface changes and updated tests