### PR TITLE
Base url configuration

### DIFF
--- a/MDCNetworking/Configuration.swift
+++ b/MDCNetworking/Configuration.swift
@@ -15,12 +15,8 @@ public enum SSLPinningMode {
 
 public struct Configuration {
     
-    public struct InvalidBaseUrl: Error {}
-    public struct UrlConstructionError: Error {}
-    public struct PathPercentEncodingError: Error {}
-
     let baseUrl: URL
-    let additionalHeaders: [String: String]
+    let httpHeaders: [String: String]
     let timeout: TimeInterval
     let sessionConfiguration: URLSessionConfiguration
     let sslPinningMode: SSLPinningMode
@@ -28,48 +24,19 @@ public struct Configuration {
 
     public init(
         baseUrl: URL,
-        additionalHeaders: [String: String]? = nil,
+        httpHeaders: [String: String]? = nil,
         timeout: TimeInterval = 60,
         sessionConfiguration: URLSessionConfiguration = .default,
         sslPinningMode: SSLPinningMode = .none,
         pinnedCertificates: [Data]? = nil
     ) {
         self.baseUrl = baseUrl
-        self.additionalHeaders = additionalHeaders ?? [:]
+        self.httpHeaders = httpHeaders ?? [:]
         self.timeout = timeout
         self.sessionConfiguration = sessionConfiguration
         self.sessionConfiguration.timeoutIntervalForRequest = timeout
         self.sslPinningMode = sslPinningMode
         self.pinnedCertificates = pinnedCertificates
-    }
-    
-    func request(path: String, parameters: [String: String]?) throws -> URLRequest {
-        
-        var mutablePath = path
-        
-        if mutablePath.first != "/" {
-            mutablePath.insert("/", at: mutablePath.startIndex)
-        }
-        
-        guard var components = URLComponents(url: baseUrl, resolvingAgainstBaseURL: true) else {
-            throw InvalidBaseUrl()
-        }
-        
-        components.path = baseUrl.path + mutablePath
-        
-        if let parameters = parameters {
-            components.queryItems = parameters.flatMap(URLQueryItem.init)
-        }
-        
-        guard let requestUrl = components.url else {
-            throw UrlConstructionError()
-        }
-        
-        var request = URLRequest(url: requestUrl)
-        
-        additionalHeaders.forEach { request.setValue($1, forHTTPHeaderField: $0) }
-        
-        return request
     }
 }
 

--- a/MDCNetworking/Configuration.swift
+++ b/MDCNetworking/Configuration.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 public enum SSLPinningMode {
-    case `default`
+    case none
     case certificate
 }
 
@@ -32,7 +32,7 @@ public struct Configuration {
         additionalHeaders: [String: String]? = nil,
         timeout: TimeInterval = 60,
         sessionConfiguration: URLSessionConfiguration = .default,
-        sslPinningMode: SSLPinningMode = .default,
+        sslPinningMode: SSLPinningMode = .none,
         pinnedCertificates: [Data]? = nil
     ) throws {
         
@@ -57,17 +57,16 @@ public struct Configuration {
     
     func request(path: String, parameters: [String: String]?) throws -> URLRequest {
         
-        guard let percentEncodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            throw PathPercentEncodingError()
-        }
-        
         var components = URLComponents()
         
         components.scheme = baseUrl.scheme
         components.host = baseUrl.host
-        components.path = percentEncodedPath
-        components.queryItems = parameters?.flatMap(URLQueryItem.init)
+        components.path = path
         
+        if let parameters = parameters {
+            components.queryItems = parameters.flatMap(URLQueryItem.init)
+        }
+
         guard let requestUrl = components.url else {
             throw UrlConstructionError()
         }

--- a/MDCNetworking/Configuration.swift
+++ b/MDCNetworking/Configuration.swift
@@ -45,16 +45,22 @@ public struct Configuration {
     
     func request(path: String, parameters: [String: String]?) throws -> URLRequest {
         
+        var mutablePath = path
+        
+        if mutablePath.first != "/" {
+            mutablePath.insert("/", at: mutablePath.startIndex)
+        }
+        
         guard var components = URLComponents(url: baseUrl, resolvingAgainstBaseURL: true) else {
             throw InvalidBaseUrl()
         }
         
-        components.path = path
+        components.path = baseUrl.path + mutablePath
         
         if let parameters = parameters {
             components.queryItems = parameters.flatMap(URLQueryItem.init)
         }
-
+        
         guard let requestUrl = components.url else {
             throw UrlConstructionError()
         }

--- a/MDCNetworking/NetworkClient.swift
+++ b/MDCNetworking/NetworkClient.swift
@@ -10,9 +10,35 @@ import Foundation
 
 open class NetworkClient {
     
-    open private (set) var configuration: Configuration
+    open let configuration: Configuration
+    open let sessionProvider: URLSessionProvider?
     
-    public init(configuration: Configuration) {
+    public init(configuration: Configuration, sessionProvider: URLSessionProvider?) {
         self.configuration = configuration
+        self.sessionProvider = sessionProvider
+    }
+    
+    open func session(
+        urlPath: String,
+        method: HTTPMethod = .get,
+        parameters: [String: String]? = nil,
+        body: Data? = nil,
+        session: URLSession? = nil,
+        completion: @escaping ResponseCallback
+    ) -> HTTPSession {
+        
+        let session = HTTPSession(
+            urlPath: urlPath,
+            method: method,
+            parameters: parameters,
+            body: body,
+            configuration: configuration,
+            session: session,
+            completion: completion
+        )
+        
+        session.sessionProvider = sessionProvider
+        
+        return session
     }
 }

--- a/MDCNetworking/NetworkClient.swift
+++ b/MDCNetworking/NetworkClient.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 open class NetworkClient {
-    
+
     open let configuration: Configuration
     open let sessionProvider: URLSessionProvider?
     

--- a/MDCNetworking/NetworkClient.swift
+++ b/MDCNetworking/NetworkClient.swift
@@ -30,13 +30,13 @@ open class NetworkClient {
         let session = HTTPSession(
             urlPath: urlPath,
             method: method,
-            parameters: parameters,
-            body: body,
             configuration: configuration,
             session: session,
             completion: completion
         )
         
+        session.request.parameters = parameters
+        session.request.body = body
         session.sessionProvider = sessionProvider
         
         return session

--- a/MDCNetworking/Session.swift
+++ b/MDCNetworking/Session.swift
@@ -99,9 +99,6 @@ public class HTTPSession: NSObject, HTTPSessionInterface {
         self.session = session
         self.completion = completion
     }
-}
-
-extension HTTPSession: HTTPSessionInterface {
     
     public func dataTaskCallback() -> (Data?, URLResponse?, Error?) -> Void {
         return { data, response, error in

--- a/MDCNetworking/Session.swift
+++ b/MDCNetworking/Session.swift
@@ -130,6 +130,7 @@ extension HTTPSession: HTTPSessionInterface {
         didReceive challenge: URLAuthenticationChallenge,
         completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void
     ) {
+        
         /*
          For reference: https://github.com/iSECPartners/ssl-conservatory
          */
@@ -149,7 +150,6 @@ extension HTTPSession: HTTPSessionInterface {
                 } else {
                     completionHandler(.useCredential, URLCredential(trust: trust))
                 }
-            
             default:
                 completionHandler(.performDefaultHandling, nil)
         }

--- a/MDCNetworkingTests/ClientTests.swift
+++ b/MDCNetworkingTests/ClientTests.swift
@@ -13,8 +13,8 @@ class ClientTests: XCTestCase {
     
     func testClientInitialization() {
         // Test with configuration
-        let session1 = try? Configuration(scheme: "https", host: "somehost")
-        let client1 = NetworkClient(configuration: session1!, sessionProvider: nil)
+        let session1 = Configuration(baseUrl: URL(string: "https://somehost")!)
+        let client1 = NetworkClient(configuration: session1, sessionProvider: nil)
         XCTAssertNotNil(client1)
         XCTAssertNotNil(client1.configuration)
     }

--- a/MDCNetworkingTests/ClientTests.swift
+++ b/MDCNetworkingTests/ClientTests.swift
@@ -13,8 +13,8 @@ class ClientTests: XCTestCase {
     
     func testClientInitialization() {
         // Test with configuration
-        let session1 = NetworkConfiguration(host: "https://somehost")
-        let client1 = NetworkClient(configuration: session1!)
+        let session1 = try? Configuration(scheme: "https", host: "somehost")
+        let client1 = NetworkClient(configuration: session1!, sessionProvider: nil)
         XCTAssertNotNil(client1)
         XCTAssertNotNil(client1.configuration)
     }

--- a/MDCNetworkingTests/ConfigurationTests.swift
+++ b/MDCNetworkingTests/ConfigurationTests.swift
@@ -24,23 +24,23 @@ class ConfigurationTests: XCTestCase {
     func testInstantiation() {
         
         // Designated initializer
-        let session1 = NetworkConfiguration(host: "https://somehost")
-        XCTAssertEqual(session1?.host.description, "https://somehost")
+        let session1 = try? Configuration(scheme: "https", host: "somehost")
+        XCTAssertEqual(session1?.baseUrl.host?.description, "somehost")
         
         // Additional headers
-        let session2 = NetworkConfiguration(host: "https://somehost",
+        let session2 = try? Configuration(scheme: "https", host: "somehost",
                                             additionalHeaders: ["Accept-Encoding":"gzip", "Content-Type":"application/json"])
         XCTAssertEqual(session2?.additionalHeaders.count, 2)
         
         // Timeout
-        let session3 = NetworkConfiguration(host: "https://somehost",
+        let session3 = try? Configuration(scheme: "https", host: "somehost",
                                             additionalHeaders: ["Accept-Encoding":"gzip", "Content-Type":"application/json"], timeout: 20)
         XCTAssertEqual(session3?.timeout, 20)
         
         // Session configuration
         let configuration = URLSessionConfiguration.default
         configuration.timeoutIntervalForRequest = 30
-        let session4 = NetworkConfiguration(host: "https://somehost",
+        let session4 = try? Configuration(scheme: "https", host: "somehost",
                                             additionalHeaders: ["Accept-Encoding":"gzip", "Content-Type":"application/json"],
                                             timeout: 20,
                                             sessionConfiguration: configuration)
@@ -50,20 +50,20 @@ class ConfigurationTests: XCTestCase {
     func testURLRequest() {
         
         // basic request
-        var session = NetworkConfiguration(host: "https://somehost")
-        var request = try! session!.request(path: "path", parameters: nil)
+        var session = try? Configuration(scheme: "https", host: "somehost")
+        var request = try! session!.request(path: "/path", parameters: nil)
 
         XCTAssertEqual(request.description, "https://somehost/path")
         
         // Single parameter
-        session = NetworkConfiguration(host: "https://somehost")
-        request = try! session!.request(path: "path", parameters: ["parameter": "value"])
+        session = try? Configuration(scheme: "https", host: "somehost")
+        request = try! session!.request(path: "/path", parameters: ["parameter": "value"])
         
         XCTAssertEqual(request.description, "https://somehost/path?parameter=value")
         
         // Two parameters
-        session = NetworkConfiguration(host: "https://somehost")
-        request = try! session!.request(path: "path", parameters: ["parameter": "value", "parameter1": "value1"])
+        session = try? Configuration(scheme: "https", host: "somehost")
+        request = try! session!.request(path: "/path", parameters: ["parameter": "value", "parameter1": "value1"])
         
         XCTAssertEqual(request.description, "https://somehost/path?parameter=value&parameter1=value1")
     }

--- a/MDCNetworkingTests/ConfigurationTests.swift
+++ b/MDCNetworkingTests/ConfigurationTests.swift
@@ -24,46 +24,46 @@ class ConfigurationTests: XCTestCase {
     func testInstantiation() {
         
         // Designated initializer
-        let session1 = try? Configuration(scheme: "https", host: "somehost")
-        XCTAssertEqual(session1?.baseUrl.host?.description, "somehost")
+        let session1 = Configuration(baseUrl: URL(string: "https://somehost")!)
+        XCTAssertEqual(session1.baseUrl.host?.description, "somehost")
         
         // Additional headers
-        let session2 = try? Configuration(scheme: "https", host: "somehost",
+        let session2 = Configuration(baseUrl: URL(string: "https://somehost")!,
                                             additionalHeaders: ["Accept-Encoding":"gzip", "Content-Type":"application/json"])
-        XCTAssertEqual(session2?.additionalHeaders.count, 2)
+        XCTAssertEqual(session2.additionalHeaders.count, 2)
         
         // Timeout
-        let session3 = try? Configuration(scheme: "https", host: "somehost",
+        let session3 = Configuration(baseUrl: URL(string: "https://somehost")!,
                                             additionalHeaders: ["Accept-Encoding":"gzip", "Content-Type":"application/json"], timeout: 20)
-        XCTAssertEqual(session3?.timeout, 20)
+        XCTAssertEqual(session3.timeout, 20)
         
         // Session configuration
         let configuration = URLSessionConfiguration.default
         configuration.timeoutIntervalForRequest = 30
-        let session4 = try? Configuration(scheme: "https", host: "somehost",
+        let session4 = Configuration(baseUrl: URL(string: "https://somehost")!,
                                             additionalHeaders: ["Accept-Encoding":"gzip", "Content-Type":"application/json"],
                                             timeout: 20,
                                             sessionConfiguration: configuration)
-        XCTAssertEqual(session4?.sessionConfiguration.timeoutIntervalForRequest, 20)
+        XCTAssertEqual(session4.sessionConfiguration.timeoutIntervalForRequest, 20)
     }
     
     func testURLRequest() {
         
         // basic request
-        var session = try? Configuration(scheme: "https", host: "somehost")
-        var request = try! session!.request(path: "/path", parameters: nil)
+        var session = Configuration(baseUrl: URL(string: "https://somehost")!)
+        var request = try! session.request(path: "/path", parameters: nil)
 
         XCTAssertEqual(request.description, "https://somehost/path")
         
         // Single parameter
-        session = try? Configuration(scheme: "https", host: "somehost")
-        request = try! session!.request(path: "/path", parameters: ["parameter": "value"])
+        session = Configuration(baseUrl: URL(string: "https://somehost")!)
+        request = try! session.request(path: "/path", parameters: ["parameter": "value"])
         
         XCTAssertEqual(request.description, "https://somehost/path?parameter=value")
         
         // Two parameters
-        session = try? Configuration(scheme: "https", host: "somehost")
-        request = try! session!.request(path: "/path", parameters: ["parameter": "value", "parameter1": "value1"])
+        session = Configuration(baseUrl: URL(string: "https://somehost")!)
+        request = try! session.request(path: "/path", parameters: ["parameter": "value", "parameter1": "value1"])
         
         XCTAssertEqual(request.description, "https://somehost/path?parameter=value&parameter1=value1")
     }

--- a/MDCNetworkingTests/ConfigurationTests.swift
+++ b/MDCNetworkingTests/ConfigurationTests.swift
@@ -11,60 +11,45 @@ import XCTest
 
 class ConfigurationTests: XCTestCase {
     
-    override func setUp() {
-        super.setUp()
-        // Put setup code here. This method is called before the invocation of each test method in the class.
+    func test_GivenDefaultValues_WhenInstantiated_ThenHasDefaultValues() {
+        let config = Configuration(baseUrl: URL(string: "https://mock-host")!)
+        
+        XCTAssertEqual(config.httpHeaders, [:])
+        XCTAssertEqual(config.timeout, 60.0)
+        XCTAssertEqual(config.sessionConfiguration, .default)
+        XCTAssertEqual(config.sslPinningMode, .none)
+        XCTAssertNil(config.pinnedCertificates)
     }
     
-    override func tearDown() {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
-        super.tearDown()
+    func test_GivenDefaultValues_WhenInstantiated_ThenSetTimeoutIntervalForRequest() {
+        let config = Configuration(baseUrl: URL(string: "https://mock-host")!)
+        
+        XCTAssertEqual(config.sessionConfiguration.timeoutIntervalForRequest, 60.0)
     }
     
-    func testInstantiation() {
+    func test_GivenValues_WhenInstantiated_ThenHasValues() {
+        let sessionConfig = URLSessionConfiguration.ephemeral
         
-        // Designated initializer
-        let session1 = Configuration(baseUrl: URL(string: "https://somehost")!)
-        XCTAssertEqual(session1.baseUrl.host?.description, "somehost")
+        let config = Configuration(
+            baseUrl: URL(string: "https://mock-host")!,
+            httpHeaders: ["mock-header": "mock-value"],
+            timeout: 30.0,
+            sessionConfiguration: sessionConfig,
+            sslPinningMode: .certificate,
+            pinnedCertificates: ["mocked-string".data(using: .utf8)!]
+        )
         
-        // Additional headers
-        let session2 = Configuration(baseUrl: URL(string: "https://somehost")!,
-                                            additionalHeaders: ["Accept-Encoding":"gzip", "Content-Type":"application/json"])
-        XCTAssertEqual(session2.additionalHeaders.count, 2)
-        
-        // Timeout
-        let session3 = Configuration(baseUrl: URL(string: "https://somehost")!,
-                                            additionalHeaders: ["Accept-Encoding":"gzip", "Content-Type":"application/json"], timeout: 20)
-        XCTAssertEqual(session3.timeout, 20)
-        
-        // Session configuration
-        let configuration = URLSessionConfiguration.default
-        configuration.timeoutIntervalForRequest = 30
-        let session4 = Configuration(baseUrl: URL(string: "https://somehost")!,
-                                            additionalHeaders: ["Accept-Encoding":"gzip", "Content-Type":"application/json"],
-                                            timeout: 20,
-                                            sessionConfiguration: configuration)
-        XCTAssertEqual(session4.sessionConfiguration.timeoutIntervalForRequest, 20)
+        XCTAssertEqual(config.httpHeaders, ["mock-header": "mock-value"])
+        XCTAssertEqual(config.timeout, 30.0)
+        XCTAssertEqual(config.sessionConfiguration, sessionConfig)
+        XCTAssertEqual(config.sslPinningMode, .certificate)
+        XCTAssertNotNil(config.pinnedCertificates)
+        XCTAssertEqual(config.pinnedCertificates!, ["mocked-string".data(using: .utf8)!])
     }
     
-    func testURLRequest() {
+    func test_GivenTimeout_WhenInstantiated_ThenSetTimeoutIntervalForRequest() {
+        let config = Configuration(baseUrl: URL(string: "https://mock-host")!, timeout: 30.0)
         
-        // basic request
-        var session = Configuration(baseUrl: URL(string: "https://somehost")!)
-        var request = try! session.request(path: "/path", parameters: nil)
-
-        XCTAssertEqual(request.description, "https://somehost/path")
-        
-        // Single parameter
-        session = Configuration(baseUrl: URL(string: "https://somehost")!)
-        request = try! session.request(path: "/path", parameters: ["parameter": "value"])
-        
-        XCTAssertEqual(request.description, "https://somehost/path?parameter=value")
-        
-        // Two parameters
-        session = Configuration(baseUrl: URL(string: "https://somehost")!)
-        request = try! session.request(path: "/path", parameters: ["parameter": "value", "parameter1": "value1"])
-        
-        XCTAssertEqual(request.description, "https://somehost/path?parameter=value&parameter1=value1")
+        XCTAssertEqual(config.sessionConfiguration.timeoutIntervalForRequest, 30.0)
     }
 }

--- a/MDCNetworkingTests/SessionTests.swift
+++ b/MDCNetworkingTests/SessionTests.swift
@@ -15,10 +15,7 @@ class SessionTests: XCTestCase {
     
         // Test with default GET method
         let configuration = Configuration(baseUrl: URL(string: "http://api.timezonedb.com")!)
-        let session1 = HTTPSession(
-            urlPath: "https://somehost",
-            configuration: configuration
-        ) { _, _, _, _ in }
+        let session1 = HTTPSession(urlPath: "https://somehost", configuration: configuration) { _, _, _, _ in }
         
         XCTAssertNotNil(session1)
         
@@ -33,13 +30,11 @@ class SessionTests: XCTestCase {
         // Prepare without Configuration object set
         let expectationForTest = expectation(description: "test")
         let configuration = Configuration(baseUrl: URL(string: "http://api.timezonedb.com")!)
-        let parameters = ["key": "1S2RMN6YBMYA", "country": "GB", "format": "json"]
         
         // Execute and test
         let session1 = HTTPSession(
             urlPath: "/v2/list-time-zone",
             method: .get,
-            parameters: parameters,
             configuration: configuration
         ) { _, result, error, wasCancelled in
                                     
@@ -52,9 +47,7 @@ class SessionTests: XCTestCase {
             expectationForTest.fulfill()
         }
         
-        XCTAssertNotNil(session1)
-        
-        session1.configuration = configuration
+        session1.request.parameters = ["key": "1S2RMN6YBMYA", "country": "GB", "format": "json"]
         
         do {
             try session1.start()
@@ -84,7 +77,6 @@ class SessionTests: XCTestCase {
         let session1 = HTTPSession(
             urlPath: "/v2/list-time-zone",
             method: .get,
-            parameters: parameters,
             configuration: configuration,
             session: stubbedSession
         ) { _, result, error, wasCancelled in
@@ -98,8 +90,7 @@ class SessionTests: XCTestCase {
             expectationForTest.fulfill()
         }
         
-        XCTAssertNotNil(session1)
-        
+        session1.request.parameters = parameters
         session1.session = stubbedSession
         
         do {
@@ -135,7 +126,6 @@ class SessionTests: XCTestCase {
         let session1 = HTTPSession(
             urlPath: "/v2/list-time-zone",
             method: .get,
-            parameters: parameters,
             configuration: configuration,
             session: stubbedSession
         ) { _, result, error, wasCancelled in
@@ -149,8 +139,7 @@ class SessionTests: XCTestCase {
             expectationForTest.fulfill()
         }
         
-        XCTAssertNotNil(session1)
-        
+        session1.request.parameters = parameters
         session1.session = stubbedSession
         
         do {
@@ -182,7 +171,6 @@ class SessionTests: XCTestCase {
         let session1 = HTTPSession(
             urlPath: "/v2/list-time-zone",
             method: .get,
-            parameters: parameters,
             configuration: configuration,
             session: stubbedSession
         ) { _, _, error, wasCancelled in
@@ -197,8 +185,7 @@ class SessionTests: XCTestCase {
             expectationForTest.fulfill()
         }
         
-        XCTAssertNotNil(session1)
-        
+        session1.request.parameters = parameters
         session1.session = stubbedSession
         
         do {

--- a/MDCNetworkingTests/SessionTests.swift
+++ b/MDCNetworkingTests/SessionTests.swift
@@ -14,7 +14,7 @@ class SessionTests: XCTestCase {
     func testInitialising() {
     
         // Test with default GET method
-        let configuration = NetworkConfiguration(host: "http://api.timezonedb.com/")
+        let configuration = try? Configuration(scheme: "http", host: "api.timezonedb.com")
         let session1 = HTTPSession(
             urlPath: "https://somehost",
             configuration: configuration!
@@ -32,7 +32,7 @@ class SessionTests: XCTestCase {
         
         // Prepare without Configuration object set
         let expectationForTest = expectation(description: "test")
-        let configuration = NetworkConfiguration(host: "http://api.timezonedb.com/")
+        let configuration = try? Configuration(scheme: "http", host: "api.timezonedb.com")
         let parameters = ["key": "1S2RMN6YBMYA", "country": "GB", "format": "json"]
         
         // Execute and test
@@ -69,7 +69,7 @@ class SessionTests: XCTestCase {
         
         // Prepare without Configuration object set
         let expectationForTest = expectation(description: "test")
-        let configuration = NetworkConfiguration(host: "http://api.timezonedb.com/")
+        let configuration = try? Configuration(scheme: "http", host: "api.timezonedb.com")
         let parameters = ["key": "1S2RMN6YBMYA", "format": "json", "country": "GB"]
         
         // Prepare stubbed session
@@ -115,7 +115,7 @@ class SessionTests: XCTestCase {
         
         // Prepare without Configuration object set
         let expectationForTest = expectation(description: "test")
-        let configuration = NetworkConfiguration(host: "http://api.timezonedb.com/")
+        let configuration = try? Configuration(scheme: "http", host: "api.timezonedb.com")
         let parameters = ["key": "1S2RMN6YBMYA", "format": "json", "country": "GB"]
         
         // Prepare stubbed session
@@ -166,7 +166,7 @@ class SessionTests: XCTestCase {
         
         // Prepare without Configuration object set
         let expectationForTest = expectation(description: "test")
-        let configuration = NetworkConfiguration(host: "http://api.timezonedb.com/")
+        let configuration = try? Configuration(scheme: "http", host: "api.timezonedb.com")
         let parameters = ["key": "1S2RMN6YBMYA", "format": "json", "country": "GB"]
         
         // Prepare stubbed session

--- a/MDCNetworkingTests/SessionTests.swift
+++ b/MDCNetworkingTests/SessionTests.swift
@@ -14,10 +14,10 @@ class SessionTests: XCTestCase {
     func testInitialising() {
     
         // Test with default GET method
-        let configuration = try? Configuration(scheme: "http", host: "api.timezonedb.com")
+        let configuration = Configuration(baseUrl: URL(string: "http://api.timezonedb.com")!)
         let session1 = HTTPSession(
             urlPath: "https://somehost",
-            configuration: configuration!
+            configuration: configuration
         ) { _, _, _, _ in }
         
         XCTAssertNotNil(session1)
@@ -32,7 +32,7 @@ class SessionTests: XCTestCase {
         
         // Prepare without Configuration object set
         let expectationForTest = expectation(description: "test")
-        let configuration = try? Configuration(scheme: "http", host: "api.timezonedb.com")
+        let configuration = Configuration(baseUrl: URL(string: "http://api.timezonedb.com")!)
         let parameters = ["key": "1S2RMN6YBMYA", "country": "GB", "format": "json"]
         
         // Execute and test
@@ -40,7 +40,7 @@ class SessionTests: XCTestCase {
             urlPath: "/v2/list-time-zone",
             method: .get,
             parameters: parameters,
-            configuration: configuration!
+            configuration: configuration
         ) { _, result, error, wasCancelled in
                                     
             XCTAssertNil(error)
@@ -54,7 +54,7 @@ class SessionTests: XCTestCase {
         
         XCTAssertNotNil(session1)
         
-        session1.configuration = configuration!
+        session1.configuration = configuration
         
         do {
             try session1.start()
@@ -69,7 +69,7 @@ class SessionTests: XCTestCase {
         
         // Prepare without Configuration object set
         let expectationForTest = expectation(description: "test")
-        let configuration = try? Configuration(scheme: "http", host: "api.timezonedb.com")
+        let configuration = Configuration(baseUrl: URL(string: "http://api.timezonedb.com")!)
         let parameters = ["key": "1S2RMN6YBMYA", "format": "json", "country": "GB"]
         
         // Prepare stubbed session
@@ -85,7 +85,7 @@ class SessionTests: XCTestCase {
             urlPath: "/v2/list-time-zone",
             method: .get,
             parameters: parameters,
-            configuration: configuration!,
+            configuration: configuration,
             session: stubbedSession
         ) { _, result, error, wasCancelled in
                                     
@@ -115,7 +115,7 @@ class SessionTests: XCTestCase {
         
         // Prepare without Configuration object set
         let expectationForTest = expectation(description: "test")
-        let configuration = try? Configuration(scheme: "http", host: "api.timezonedb.com")
+        let configuration = Configuration(baseUrl: URL(string: "http://api.timezonedb.com")!)
         let parameters = ["key": "1S2RMN6YBMYA", "format": "json", "country": "GB"]
         
         // Prepare stubbed session
@@ -136,7 +136,7 @@ class SessionTests: XCTestCase {
             urlPath: "/v2/list-time-zone",
             method: .get,
             parameters: parameters,
-            configuration: configuration!,
+            configuration: configuration,
             session: stubbedSession
         ) { _, result, error, wasCancelled in
                                     
@@ -166,7 +166,7 @@ class SessionTests: XCTestCase {
         
         // Prepare without Configuration object set
         let expectationForTest = expectation(description: "test")
-        let configuration = try? Configuration(scheme: "http", host: "api.timezonedb.com")
+        let configuration = Configuration(baseUrl: URL(string: "http://api.timezonedb.com")!)
         let parameters = ["key": "1S2RMN6YBMYA", "format": "json", "country": "GB"]
         
         // Prepare stubbed session
@@ -183,7 +183,7 @@ class SessionTests: XCTestCase {
             urlPath: "/v2/list-time-zone",
             method: .get,
             parameters: parameters,
-            configuration: configuration!,
+            configuration: configuration,
             session: stubbedSession
         ) { _, _, error, wasCancelled in
                                     


### PR DESCRIPTION
Contains previous PR. 

Configuration now takes a `URL` as `baseURL` parameter instead of `host` and `schema` strings